### PR TITLE
[Bug] Merkle Tree Whitelist uses wrong proof

### DIFF
--- a/web/components/web3/mint-nft.js
+++ b/web/components/web3/mint-nft.js
@@ -103,7 +103,7 @@ const MintNFT = () => {
     }
     validateClaim();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [giftProof])
+  }, [whitelistProof])
 
 
   const onMintGift = async () => {


### PR DESCRIPTION
`useEffect` for main whitelist uses `giftProof` as a dependency instead of whitelist proof. Bug was uncaught due to the eslint disable.